### PR TITLE
feat(http): add FormBody extractor and #[form] attribute

### DIFF
--- a/crates/ironic-http/src/extract.rs
+++ b/crates/ironic-http/src/extract.rs
@@ -190,6 +190,73 @@ where
     }
 }
 
+/// Deserializes an `application/x-www-form-urlencoded` request body into `T`.
+///
+/// Use with `#[form]` on controller methods, or construct manually for
+/// handwritten route definitions:
+///
+/// ```ignore
+/// RouteDefinition::post("/login")
+///     .parameter(FormBody::<LoginForm>::new())
+/// ```
+#[derive(Debug, Default)]
+pub struct FormBody<T>(PhantomData<fn() -> T>);
+
+impl<T> FormBody<T> {
+    /// Creates a URL-encoded form body extractor.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+fn is_urlencoded_content_type(headers: &http::HeaderMap) -> bool {
+    headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value.split(';').next().is_some_and(|media_type| {
+                media_type
+                    .trim()
+                    .eq_ignore_ascii_case("application/x-www-form-urlencoded")
+            })
+        })
+}
+
+impl<T> ParameterExtractor for FormBody<T>
+where
+    T: DeserializeOwned + Send + Sync + 'static,
+{
+    fn extract<'a>(&'a self, context: &'a mut RequestContext) -> ExtractFuture<'a> {
+        Box::pin(async move {
+            if !is_urlencoded_content_type(context.request().headers()) {
+                return Err(HttpError::bad_request(
+                    "RF_HTTP_INVALID_FORM_CONTENT_TYPE",
+                    "Expected Content-Type application/x-www-form-urlencoded",
+                ));
+            }
+
+            let body = std::str::from_utf8(context.request().body()).map_err(|_| {
+                HttpError::bad_request(
+                    "RF_HTTP_INVALID_FORM_BODY",
+                    "Form request body must be valid UTF-8",
+                )
+            })?;
+            let value = serde_urlencoded::from_str::<T>(body).map_err(|error| {
+                HttpError::bad_request(
+                    "RF_HTTP_INVALID_FORM_BODY",
+                    format!("Invalid form request body: {error}"),
+                )
+            })?;
+            Ok(Box::new(value) as ExtractedValue)
+        })
+    }
+
+    fn description(&self) -> &'static str {
+        "URL-encoded form body"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use http::Uri;
@@ -262,5 +329,66 @@ mod tests {
             .downcast::<u32>()
             .unwrap();
         assert_eq!(*value, 7);
+    }
+
+    fn form_context(body: &str) -> RequestContext {
+        let mut request = context("/login", body.as_bytes());
+        request.request_mut().headers_mut().insert(
+            http::header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded".parse().unwrap(),
+        );
+        request
+    }
+
+    #[tokio::test]
+    async fn extracts_form_bodies() {
+        let value = FormBody::<Payload>::new()
+            .extract(&mut form_context("name=Ada"))
+            .await
+            .unwrap()
+            .downcast::<Payload>()
+            .unwrap();
+        assert_eq!(value.name, "Ada");
+    }
+
+    #[tokio::test]
+    async fn accepts_form_content_type_with_charset() {
+        let mut request = context("/login", b"name=Ada");
+        request.request_mut().headers_mut().insert(
+            http::header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded; charset=UTF-8"
+                .parse()
+                .unwrap(),
+        );
+        let value = FormBody::<Payload>::new()
+            .extract(&mut request)
+            .await
+            .unwrap()
+            .downcast::<Payload>()
+            .unwrap();
+        assert_eq!(value.name, "Ada");
+    }
+
+    #[tokio::test]
+    async fn rejects_wrong_form_content_type() {
+        let mut request = context("/login", b"name=Ada");
+        request.request_mut().headers_mut().insert(
+            http::header::CONTENT_TYPE,
+            "application/json".parse().unwrap(),
+        );
+        let error = FormBody::<Payload>::new()
+            .extract(&mut request)
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), "RF_HTTP_INVALID_FORM_CONTENT_TYPE");
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_form_bodies() {
+        let error = FormBody::<Payload>::new()
+            .extract(&mut form_context(""))
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), "RF_HTTP_INVALID_FORM_BODY");
     }
 }

--- a/crates/ironic-http/src/lib.rs
+++ b/crates/ironic-http/src/lib.rs
@@ -20,8 +20,8 @@ pub use error::HttpError;
 pub(crate) use exception_filter::ExceptionFilterSet;
 pub use exception_filter::{ExceptionFilter, FilterContext};
 pub use extract::{
-    ExtractFuture, ExtractedValue, HeaderParameter, JsonBody, ParameterExtractor, PathParameter,
-    QueryParameters,
+    ExtractFuture, ExtractedValue, FormBody, HeaderParameter, JsonBody, ParameterExtractor,
+    PathParameter, QueryParameters,
 };
 pub use handler::{ErasedHandler, HandlerArguments, HandlerFuture, handler_fn};
 pub use metadata::{CacheMetadata, VersionMetadata, VersioningStrategy};

--- a/crates/ironic-macros/src/lib.rs
+++ b/crates/ironic-macros/src/lib.rs
@@ -87,6 +87,7 @@ marker_attribute!(
     head,
     options,
     body,
+    form,
     query,
     param,
     header,

--- a/crates/ironic-macros/src/routes.rs
+++ b/crates/ironic-macros/src/routes.rs
@@ -437,6 +437,15 @@ fn take_extractor(
                     ));
                 }
             }
+            "form" => {
+                let value = quote!(::ironic::FormBody::<#argument_type>::new());
+                if extractor.replace(value).is_some() {
+                    return Err(syn::Error::new_spanned(
+                        argument_name,
+                        "a route parameter must have exactly one extractor attribute",
+                    ));
+                }
+            }
             "query" => {
                 let value = quote!(::ironic::QueryParameters::<#argument_type>::new());
                 if extractor.replace(value).is_some() {
@@ -489,7 +498,7 @@ fn take_extractor(
     let extractor = extractor.ok_or_else(|| {
         syn::Error::new_spanned(
             argument_name,
-            "route parameters require one of `#[body]`, `#[query]`, `#[param]`, `#[header]`, or `#[custom(ExtractorType)]`",
+            "route parameters require one of `#[body]`, `#[form]`, `#[query]`, `#[param]`, `#[header]`, or `#[custom(ExtractorType)]`",
         )
     })?;
     Ok((extractor, pipes))

--- a/crates/ironic/tests/ui/fail/missing_extractor.stderr
+++ b/crates/ironic/tests/ui/fail/missing_extractor.stderr
@@ -1,4 +1,4 @@
-error: route parameters require one of `#[body]`, `#[query]`, `#[param]`, `#[header]`, or `#[custom(ExtractorType)]`
+error: route parameters require one of `#[body]`, `#[form]`, `#[query]`, `#[param]`, `#[header]`, or `#[custom(ExtractorType)]`
   --> crates/ironic/tests/ui/fail/missing_extractor.rs:11:29
    |
 11 |     async fn invalid(&self, value: String) -> Result<(), HttpError> {

--- a/docs/content/docs/core/macros.md
+++ b/docs/content/docs/core/macros.md
@@ -141,6 +141,12 @@ async fn create(
     #[header("x-api-key")] key: String, // Request header
 ) -> Result<Json<User>, HttpError> { ... }
 
+#[post("/login")]
+async fn login(
+    &self,
+    #[form] credentials: LoginForm,     // application/x-www-form-urlencoded
+) -> Result<Json<Token>, HttpError> { ... }
+
 #[get("/users/:id")]
 async fn show(
     &self,
@@ -152,12 +158,14 @@ async fn show(
 |-----------|--------|---------|
 | `#[param]` | Path segment (`/:name`) | `/users/42` → `42` |
 | `#[body]` | Request body (JSON) | `POST` with `{"name":"Alice"}` |
+| `#[form]` | Request body (URL-encoded form) | `POST` with `name=Alice&age=30` |
 | `#[query]` | Query string | `?filter=active` |
 | `#[header("name")]` | Request header | `Authorization: Bearer ...` |
 
 **Common mistakes:**
 - Using `#[param]` on a route that doesn't declare the corresponding `:param` in its path — runtime panic.
 - Forgetting `#[body]` when you need the JSON payload — the argument gets the wrong extractor.
+- Using `#[form]` without `Content-Type: application/x-www-form-urlencoded` — the request is rejected with `400`.
 
 ---
 
@@ -248,7 +256,7 @@ The macro registers the WebSocket upgrade handler at the given path. Message han
 - [x] `#[derive(Injectable)]` with `#[injectable(...)]` controls scope and eager init
 - [x] `#[controller("/prefix")]` + `#[routes]` declare HTTP endpoints
 - [x] `#[get]`, `#[post]`, `#[put]`, `#[delete]`, `#[patch]`, `#[head]`, `#[options]` map HTTP verbs
-- [x] `#[param]`, `#[body]`, `#[query]`, `#[header]` extract request data
+- [x] `#[param]`, `#[body]`, `#[form]`, `#[query]`, `#[header]` extract request data
 - [x] `#[use_guard]` and `#[use_interceptor]` plug into the request pipeline
 - [x] `#[ironic::main]` sets up the async runtime
 - [x] `#[web_socket_gateway]` + `#[subscribe_message]` handle WebSocket connections

--- a/openspec/specs/procedural-macros/spec.md
+++ b/openspec/specs/procedural-macros/spec.md
@@ -35,8 +35,12 @@ The `#[controller(path)]` derive macro SHALL generate metadata associating the c
 - **THEN** a `RouteDefinition` SHALL be generated matching GET method and the path pattern
 
 ### Requirement: Parameter attribute macros SHALL generate extraction code
-`#[body]`, `#[param]`, `#[query]`, `#[header]` macros SHALL generate parameter extraction code for the annotated handler parameter.
+`#[body]`, `#[form]`, `#[param]`, `#[query]`, `#[header]` macros SHALL generate parameter extraction code for the annotated handler parameter.
 
 #### Scenario: Body attribute generates deserialization
 - **WHEN** a handler parameter is annotated with `#[body]`
-- **THEN** extraction code SHALL deserialize the request body into the parameter type
+- **THEN** extraction code SHALL deserialize the JSON request body into the parameter type
+
+#### Scenario: Form attribute generates URL-encoded deserialization
+- **WHEN** a handler parameter is annotated with `#[form]`
+- **THEN** extraction code SHALL deserialize an `application/x-www-form-urlencoded` body into the parameter type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub use http_impl::{
 };
 pub use ironic_macros::{
     Injectable, Module, OpenApiSchema, Serializable, api, body, cache, controller, cron, custom,
-    delete, get, head, header, interval, main, options, param, patch, pipe, post, put, query,
+    delete, form, get, head, header, interval, main, options, param, patch, pipe, post, put, query,
     req_body, resp, routes, subscribe_message, r#test, timeout, use_guard, use_interceptor,
     web_socket_gateway,
 };
@@ -183,17 +183,17 @@ pub mod prelude {
     pub use crate::{
         AxumAdapter, BuildInfo, CacheMetadata, CompiledHttpApplication, ConfigurationError,
         ConfigurationLoader, ControllerDefinition, Dependency, ExceptionFilter, FeatureToggle,
-        FilterContext, FrameworkApplication, FrameworkError, FrameworkResult, Guard, GuardDecision,
-        GuardFuture, HeaderParameter, HealthModule, HealthStatus, HttpError, HttpMethod,
-        HttpPlatformAdapter, HttpPlatformApplication, Injectable, Interceptor, InterceptorNext,
-        Json, JsonBody, LifecycleDefinition, Middleware, Module, ModuleDefinition, ModuleRef,
-        OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy, OnModuleInit,
+        FilterContext, FormBody, FrameworkApplication, FrameworkError, FrameworkResult, Guard,
+        GuardDecision, GuardFuture, HeaderParameter, HealthModule, HealthStatus, HttpError,
+        HttpMethod, HttpPlatformAdapter, HttpPlatformApplication, Injectable, Interceptor,
+        InterceptorNext, Json, JsonBody, LifecycleDefinition, Middleware, Module, ModuleDefinition,
+        ModuleRef, OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy, OnModuleInit,
         ParameterPipe, PathParameter, PipelineFuture, ProviderDefinition, QueryParameters,
         RequestContext, RequestId, RequestScope, RequestTracing, RouteDefinition, RouteMetadata,
         Scope, Secret, SecretString, Serializable, ShutdownSignal, ValidateConfiguration,
         VersionMetadata, VersioningStrategy, WsGatewayDefinition, api, body, cache, controller,
-        create_param_decorator, cron, custom, delete, get, handler_fn, head, header, interval,
-        options, param, patch, pipe, pipe_fn, post, put, query, req_body, resp, routes,
+        create_param_decorator, cron, custom, delete, form, get, handler_fn, head, header,
+        interval, options, param, patch, pipe, pipe_fn, post, put, query, req_body, resp, routes,
         subscribe_message, timeout, use_guard, use_interceptor, web_socket_gateway,
     };
     #[cfg(feature = "serialization")]


### PR DESCRIPTION
## Description

Adds first-class `application/x-www-form-urlencoded` request body support, which Axum (`Form`) and Actix Web (`web::Form`) already provide but Ironic only covered via query strings and multipart.

- New `FormBody<T>` extractor in `ironic-http`
- New `#[form]` parameter attribute (alongside `#[body]` for JSON)
- Rejects non-form Content-Types with `RF_HTTP_INVALID_FORM_CONTENT_TYPE`
- Docs + OpenSpec updates
- Unit tests for happy path, charset Content-Type, wrong Content-Type, and malformed bodies

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Test addition / improvement

## Checklist

### Code Style

- [x] My code follows existing patterns in the codebase
- [x] I have NOT added unnecessary comments — code should be self-documenting. Comments are only allowed for non-obvious logic
- [x] My functions are small and focused on a single responsibility
- [x] All public APIs I introduced are documented (doc comments on types, methods, and public module exports)

### Testing

- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass (`cargo test --workspace --all-features`) — note: `blog-api` `test_stats` fails on main unrelated to this change; FormBody tests and workspace excluding blog-api pass

### Quality

- [x] I have run `cargo fmt --all -- --check` — formatting is correct
- [x] I have run `cargo clippy --workspace --all-targets --all-features -- -D warnings` — no warnings
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have updated documentation if needed
- [ ] I have added a changelog entry in `RELEASE_NOTES.md` if applicable (`RELEASE_NOTES.md` is still the stale 0.1 preview; skipped)

## Additional Context

Contribution inspired by gaps vs Axum/Actix Web extractors. Usage:

```rust
#[post("/login")]
async fn login(&self, #[form] credentials: LoginForm) -> Result<Json<Token>, HttpError> {
    ...
}
```


Made with [Cursor](https://cursor.com)