### PR TITLE
docs(site): refresh landing page brand, logo, and hero

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,6 +10,12 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/logo.svg" />
     <link rel="manifest" href="/site.webmanifest" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,600;1,9..144,500;1,9..144,600&family=IBM+Plex+Mono:wght@400;500&family=Syne:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Ironic" />
     <meta property="og:title" content="Ironic Framework" />

--- a/docs/lib/theme.ts
+++ b/docs/lib/theme.ts
@@ -121,9 +121,10 @@ function createAccentVariables(
 }
 
 const shared: ThemeVariables = {
-  '--theme-font-sans': '"Inter", "Segoe UI", sans-serif',
-  '--theme-font-mono': '"SFMono-Regular", "Consolas", monospace',
-  '--theme-font-serif': '"Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif',
+  '--theme-font-sans': '"DM Sans", "Segoe UI", sans-serif',
+  '--theme-font-mono': '"IBM Plex Mono", "SFMono-Regular", "Consolas", monospace',
+  '--theme-font-serif': '"Fraunces", "Iowan Old Style", "Palatino Linotype", serif',
+  '--theme-font-display': '"Syne", "DM Sans", sans-serif',
   '--theme-radius': '0.625rem',
 };
 
@@ -227,7 +228,7 @@ export const DOCS_THEME_STORAGE_KEYS = {
 } as const;
 
 export const DEFAULT_DOCS_THEME_ACCENT: DocsThemeAccent = 'custom';
-export const DEFAULT_DOCS_CUSTOM_ACCENT = '#64748b';
+export const DEFAULT_DOCS_CUSTOM_ACCENT = '#e07840';
 
 export const DOCS_THEME_ACCENTS: Record<PresetDocsThemeAccent, AccentPreset> = {
   amber: {

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,28 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" role="img" aria-label="Ironic">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#1e1b4b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <linearGradient id="accent" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#a78bfa"/>
-      <stop offset="30%" stop-color="#7c3aed"/>
-      <stop offset="70%" stop-color="#f59e0b"/>
-      <stop offset="100%" stop-color="#f97316"/>
-    </linearGradient>
-    <linearGradient id="glow" x1="8" y1="8" x2="24" y2="24" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#c4b5fd" stop-opacity="0.6"/>
-      <stop offset="100%" stop-color="#fbbf24" stop-opacity="0.3"/>
+    <linearGradient id="f-mark" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#F0A36A"/>
+      <stop offset="100%" stop-color="#E07840"/>
     </linearGradient>
   </defs>
-  <!-- Background -->
-  <rect width="32" height="32" rx="8" fill="url(#bg)"/>
-  <!-- Glow ring -->
-  <rect x="1" y="1" width="30" height="30" rx="7" fill="none" stroke="url(#accent)" stroke-width="0.5" opacity="0.5"/>
-  <!-- "I" lettermark -->
-  <rect x="9" y="6" width="14" height="3.5" rx="1.75" fill="url(#accent)"/>
-  <rect x="13.25" y="10.5" width="5.5" height="11" rx="2.75" fill="url(#accent)"/>
-  <rect x="9" y="22.5" width="14" height="3.5" rx="1.75" fill="url(#accent)"/>
-  <!-- Subtle dot accent bottom-right -->
-  <circle cx="26" cy="26" r="1.5" fill="url(#accent)" opacity="0.4"/>
+  <rect width="32" height="32" rx="8" fill="#0B101A"/>
+  <rect x="9" y="6" width="14" height="3.5" rx="1.75" fill="url(#f-mark)"/>
+  <rect x="12.5" y="10.5" width="7" height="11" rx="3.5" fill="url(#f-mark)"/>
+  <rect x="9" y="22.5" width="14" height="3.5" rx="1.75" fill="url(#f-mark)"/>
+  <circle cx="6" cy="8" r="1.2" fill="#7DD3C0"/>
+  <circle cx="26" cy="24" r="1.2" fill="#7DD3C0"/>
 </svg>

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,54 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none" role="img" aria-label="Ironic">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="128" y2="128" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#1e1b4b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <linearGradient id="ironic-mark" x1="18" y1="12" x2="110" y2="116" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#F0A36A"/>
+      <stop offset="55%" stop-color="#E07840"/>
+      <stop offset="100%" stop-color="#B85A2A"/>
     </linearGradient>
-    <linearGradient id="accent1" x1="20" y1="20" x2="108" y2="108" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#a78bfa"/>
-      <stop offset="40%" stop-color="#7c3aed"/>
-      <stop offset="70%" stop-color="#f59e0b"/>
-      <stop offset="100%" stop-color="#f97316"/>
+    <linearGradient id="ironic-panel" x1="0" y1="0" x2="128" y2="128" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#182033"/>
+      <stop offset="100%" stop-color="#0B101A"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="64" y1="0" x2="64" y2="128" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#c4b5fd"/>
-      <stop offset="50%" stop-color="#a78bfa"/>
-      <stop offset="100%" stop-color="#fbbf24"/>
-    </linearGradient>
-    <filter id="glow">
-      <feGaussianBlur stdDeviation="3" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
-    </filter>
   </defs>
-  <!-- Background rounded square -->
-  <rect width="128" height="128" rx="24" fill="url(#bg)"/>
-  <!-- Subtle grid pattern -->
-  <g opacity="0.06">
-    <line x1="0" y1="32" x2="128" y2="32" stroke="#fff" stroke-width="0.5"/>
-    <line x1="0" y1="64" x2="128" y2="64" stroke="#fff" stroke-width="0.5"/>
-    <line x1="0" y1="96" x2="128" y2="96" stroke="#fff" stroke-width="0.5"/>
-    <line x1="32" y1="0" x2="32" y2="128" stroke="#fff" stroke-width="0.5"/>
-    <line x1="64" y1="0" x2="64" y2="128" stroke="#fff" stroke-width="0.5"/>
-    <line x1="96" y1="0" x2="96" y2="128" stroke="#fff" stroke-width="0.5"/>
-  </g>
-  <!-- Outer ring -->
-  <rect x="4" y="4" width="120" height="120" rx="20" fill="none" stroke="url(#accent1)" stroke-width="1" opacity="0.4"/>
-  <!-- Inner ring -->
-  <rect x="12" y="12" width="104" height="104" rx="14" fill="none" stroke="url(#accent2)" stroke-width="0.75" opacity="0.15"/>
-  <!-- Corner accents -->
-  <circle cx="24" cy="24" r="3" fill="url(#accent2)" opacity="0.3"/>
-  <circle cx="104" cy="24" r="3" fill="url(#accent2)" opacity="0.3"/>
-  <circle cx="24" cy="104" r="3" fill="url(#accent2)" opacity="0.3"/>
-  <circle cx="104" cy="104" r="3" fill="url(#accent2)" opacity="0.3"/>
-  <!-- "I" lettermark with glow -->
-  <g filter="url(#glow)">
-    <rect x="34" y="34" width="60" height="13" rx="6.5" fill="url(#accent1)"/>
-    <rect x="50" y="52" width="28" height="40" rx="14" fill="url(#accent1)"/>
-    <rect x="34" y="97" width="60" height="13" rx="6.5" fill="url(#accent1)"/>
-  </g>
-  <!-- Module dots (like DI graph nodes) -->
-  <circle cx="18" cy="64" r="2" fill="#c4b5fd" opacity="0.5"/>
-  <circle cx="110" cy="64" r="2" fill="#fbbf24" opacity="0.5"/>
-  <circle cx="64" cy="8" r="2" fill="#c4b5fd" opacity="0.3"/>
-  <circle cx="64" cy="120" r="2" fill="#fbbf24" opacity="0.3"/>
+  <rect width="128" height="128" rx="28" fill="url(#ironic-panel)"/>
+  <path d="M28 34h72" stroke="#2A3548" stroke-width="1.5" stroke-linecap="round" opacity="0.9"/>
+  <path d="M28 64h72" stroke="#2A3548" stroke-width="1.5" stroke-linecap="round" opacity="0.55"/>
+  <path d="M28 94h72" stroke="#2A3548" stroke-width="1.5" stroke-linecap="round" opacity="0.9"/>
+  <circle cx="28" cy="34" r="4" fill="#7DD3C0"/>
+  <circle cx="100" cy="34" r="4" fill="#F0A36A"/>
+  <circle cx="28" cy="94" r="4" fill="#F0A36A"/>
+  <circle cx="100" cy="94" r="4" fill="#7DD3C0"/>
+  <path d="M28 34H100M28 94H100" stroke="url(#ironic-mark)" stroke-width="1" opacity="0.35"/>
+  <rect x="40" y="28" width="48" height="12" rx="6" fill="url(#ironic-mark)"/>
+  <rect x="52" y="44" width="24" height="40" rx="12" fill="url(#ironic-mark)"/>
+  <rect x="40" y="88" width="48" height="12" rx="6" fill="url(#ironic-mark)"/>
 </svg>

--- a/docs/public/site.webmanifest
+++ b/docs/public/site.webmanifest
@@ -4,8 +4,8 @@
   "description": "A batteries-included, type-safe application framework for Rust",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#f59e0b",
+  "background_color": "#0b101a",
+  "theme_color": "#e07840",
   "icons": [
     {
       "src": "/favicon.svg",

--- a/docs/src/pages/home/components/code-showcase.tsx
+++ b/docs/src/pages/home/components/code-showcase.tsx
@@ -15,7 +15,7 @@ const CodeShowcase = () => {
         <section className='relative py-24 px-6 max-w-7xl mx-auto border-t border-fd-border'>
             <div className='grid grid-cols-1 lg:grid-cols-2 gap-12 items-center'>
                 <FadeUp>
-                    <h2 className='text-3xl md:text-4xl font-bold text-fd-foreground tracking-tight mb-6'>
+                    <h2 className='font-display text-3xl md:text-4xl font-bold text-fd-foreground tracking-tight mb-6'>
                         APIs that feel{' '}
                         <span className='text-brand'>natural</span>
                     </h2>

--- a/docs/src/pages/home/components/comparison-table.tsx
+++ b/docs/src/pages/home/components/comparison-table.tsx
@@ -222,7 +222,7 @@ const ComparisonTable = () => {
             </div>
 
             <FadeUp className='text-center max-w-2xl mx-auto mb-16 relative'>
-                <h2 className='text-3xl md:text-4xl font-bold text-fd-foreground tracking-tight mb-4'>
+                <h2 className='font-display text-3xl md:text-4xl font-bold text-fd-foreground tracking-tight mb-4'>
                     How <span className='text-brand'>Ironic</span> compares
                 </h2>
                 <p className='text-fd-muted-foreground text-base font-medium leading-relaxed'>

--- a/docs/src/pages/home/components/cta.tsx
+++ b/docs/src/pages/home/components/cta.tsx
@@ -11,14 +11,14 @@ const CTA = () => {
             <div className='absolute -top-40 left-1/2 -translate-x-1/2 w-175 h-100 bg-brand/4 rounded-full blur-[120px] pointer-events-none' />
 
             <FadeUp className='relative max-w-2xl mx-auto px-6 flex flex-col items-center text-center z-10'>
-                <h2 className='text-3xl md:text-4xl font-bold text-fd-foreground tracking-tight mb-4'>
+                <h2 className='font-display text-3xl md:text-4xl font-bold text-fd-foreground tracking-tight mb-4'>
                     Start building today
                 </h2>
                 <p className='text-base text-fd-muted-foreground font-medium mb-3'>
                     Install the CLI, scaffold a project, and have a running
                     API in under 60 seconds.
                 </p>
-                <div className='inline-flex items-center gap-2 rounded-full border border-fd-border bg-fd-card/50 px-4 py-2 text-xs font-mono text-fd-muted-foreground mb-8'>
+                <div className='inline-flex items-center gap-2 rounded-xl border border-fd-border bg-fd-card/50 px-4 py-2 text-xs font-mono text-fd-muted-foreground mb-8'>
                     <Terminal className='w-3.5 h-3.5 text-brand' />
                     <span>cargo install ironic</span>
                 </div>
@@ -26,7 +26,7 @@ const CTA = () => {
                     <Button
                         asChild
                         size='lg'
-                        className='h-12 px-8 rounded-full bg-brand hover:bg-brand/90 text-white font-semibold text-sm shadow-lg shadow-brand/20 transition-all hover:shadow-brand/30 hover:scale-[1.02]'>
+                        className='h-12 px-8 rounded-xl bg-brand hover:bg-brand/90 text-white font-semibold text-sm shadow-[0_16px_40px_-18px_rgba(224,120,64,0.75)] transition-all hover:scale-[1.02]'>
                         <Link to='/docs/getting-started'>
                             Get started
                             <ArrowRight className='ml-2 w-4 h-4' />
@@ -36,7 +36,7 @@ const CTA = () => {
                         asChild
                         variant='outline'
                         size='lg'
-                        className='h-12 px-8 rounded-full border-fd-border hover:bg-fd-accent font-semibold text-sm transition-all'>
+                        className='h-12 px-8 rounded-xl border-fd-border hover:bg-fd-accent font-semibold text-sm transition-all'>
                         <a
                             href='https://github.com/ironic-org/ironic'
                             target='_blank'

--- a/docs/src/pages/home/components/features.tsx
+++ b/docs/src/pages/home/components/features.tsx
@@ -49,7 +49,7 @@ const Features = () => {
             </div>
 
             <FadeUp className='text-center max-w-2xl mx-auto mb-16 relative'>
-                <h2 className='text-3xl md:text-4xl font-bold text-fd-foreground tracking-tight mb-4'>
+                <h2 className='font-display text-3xl md:text-4xl font-bold text-fd-foreground tracking-tight mb-4'>
                     Everything you need to build{' '}
                     <span className='text-brand'>production APIs</span>
                 </h2>

--- a/docs/src/pages/home/components/footer.tsx
+++ b/docs/src/pages/home/components/footer.tsx
@@ -1,4 +1,4 @@
-import { Github, Layers } from 'lucide-react';
+import { Github } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 const footerLinks = {
@@ -28,11 +28,15 @@ const Footer = () => {
             <div className='mx-auto max-w-7xl px-6 py-16'>
                 <div className='grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-4'>
                     <div>
-                        <div className='flex items-center gap-2 mb-4'>
-                            <span className='flex items-center justify-center rounded-lg border border-brand/20 bg-brand/10 p-1.5 text-brand'>
-                                <Layers className='h-5 w-5' />
-                            </span>
-                            <span className='text-lg font-bold tracking-tight text-fd-foreground'>
+                        <div className='mb-4 flex items-center gap-2.5'>
+                            <img
+                                src='/logo.svg'
+                                alt=''
+                                width={28}
+                                height={28}
+                                className='size-7 rounded-lg'
+                            />
+                            <span className='font-display text-lg font-bold tracking-tight text-fd-foreground'>
                                 Ironic
                             </span>
                         </div>

--- a/docs/src/pages/home/components/hero-section.tsx
+++ b/docs/src/pages/home/components/hero-section.tsx
@@ -1,133 +1,95 @@
 import { Button } from '@/components/ui/button';
-import { ArrowRight, Copy, Github, Terminal } from 'lucide-react';
-import { useState } from 'react';
+import { ArrowRight, Github } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import FadeUp from './fade-up';
 import { GitHubStarButton } from './github-stars';
-import { CURRENT_VERSION_TAG } from '@/lib/constants';
 
 const HeroSection = () => {
-    const [copied, setCopied] = useState(false);
-    const installCmd = 'cargo install ironic';
-
-    function handleCopy() {
-        navigator.clipboard.writeText(installCmd);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-    }
-
     return (
-        <section className='relative pt-28 pb-16 px-6 max-w-7xl mx-auto flex flex-col items-center text-center overflow-hidden'>
-            <div className='absolute inset-0 pointer-events-none overflow-hidden'>
-                <div className='absolute -top-40 left-1/4 w-150 h-150 bg-brand/8 rounded-full blur-[120px] animate-glow' />
-                <div className='absolute -bottom-40 right-1/4 w-125 h-125 bg-brand/5 rounded-full blur-[100px] animate-glow' style={{ animationDelay: '1s' }} />
+        <section className='relative min-h-[100svh] overflow-hidden'>
+            <div className='absolute inset-0 pointer-events-none' aria-hidden='true'>
+                <div className='absolute inset-0 bg-[radial-gradient(ellipse_at_20%_0%,rgba(224,120,64,0.18),transparent_45%),radial-gradient(ellipse_at_85%_15%,rgba(125,211,192,0.12),transparent_40%),linear-gradient(180deg,rgba(11,16,26,0.04),transparent_35%,var(--color-fd-background))]' />
+                <div className='absolute -top-24 left-1/2 h-[42rem] w-[42rem] -translate-x-1/2 rounded-full bg-brand/10 blur-[100px] animate-drift' />
+                <div className='absolute bottom-0 right-0 h-[28rem] w-[28rem] translate-x-1/4 translate-y-1/4 rounded-full bg-[rgba(125,211,192,0.08)] blur-[90px] animate-drift' style={{ animationDelay: '4s' }} />
+                <svg
+                    className='absolute inset-x-0 bottom-0 h-[55%] w-full opacity-[0.55] dark:opacity-70'
+                    viewBox='0 0 1200 520'
+                    fill='none'
+                    preserveAspectRatio='xMidYMax slice'>
+                    <path d='M120 120H420M420 120V260M420 260H780M780 260V400M780 400H1080' stroke='currentColor' className='text-fd-border' strokeWidth='1.5' />
+                    <path d='M220 400H520M520 400V200M520 200H900' stroke='currentColor' className='text-brand/25' strokeWidth='1.5' />
+                    <circle className='animate-node-pulse' cx='120' cy='120' r='7' fill='#7DD3C0' />
+                    <circle className='animate-node-pulse' style={{ animationDelay: '0.6s' }} cx='420' cy='120' r='7' fill='#E07840' />
+                    <circle className='animate-node-pulse' style={{ animationDelay: '1.2s' }} cx='420' cy='260' r='7' fill='#7DD3C0' />
+                    <circle className='animate-node-pulse' style={{ animationDelay: '1.8s' }} cx='780' cy='260' r='7' fill='#E07840' />
+                    <circle className='animate-node-pulse' style={{ animationDelay: '2.4s' }} cx='780' cy='400' r='7' fill='#7DD3C0' />
+                    <circle className='animate-node-pulse' style={{ animationDelay: '3s' }} cx='1080' cy='400' r='7' fill='#E07840' />
+                    <circle className='animate-node-pulse' style={{ animationDelay: '0.9s' }} cx='220' cy='400' r='6' fill='#E07840' />
+                    <circle className='animate-node-pulse' style={{ animationDelay: '1.5s' }} cx='520' cy='400' r='6' fill='#7DD3C0' />
+                    <circle className='animate-node-pulse' style={{ animationDelay: '2.1s' }} cx='520' cy='200' r='6' fill='#E07840' />
+                    <circle className='animate-node-pulse' style={{ animationDelay: '2.7s' }} cx='900' cy='200' r='6' fill='#7DD3C0' />
+                </svg>
             </div>
 
-            <FadeUp>
-                <a
-                    href='https://github.com/ironic-org/ironic'
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    className='group relative inline-flex items-center gap-3 rounded-full border border-fd-border bg-fd-card/50 px-4 py-1.5 text-xs font-medium text-fd-muted-foreground hover:border-fd-accent hover:text-fd-foreground transition-all mb-8'>
-                    <span className='relative flex h-2 w-2'>
-                        <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-75' />
-                        <span className='relative inline-flex h-2 w-2 rounded-full bg-emerald-500' />
-                    </span>
-                    {CURRENT_VERSION_TAG} — available on GitHub
-                    <ArrowRight className='w-3 h-3 group-hover:translate-x-0.5 transition-transform' />
-                </a>
-            </FadeUp>
-
-            <FadeUp delay='100ms'>
-                <h1 className='text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-bold tracking-tighter text-fd-foreground leading-[1.05] mb-6 max-w-5xl'>
-                    A type-safe
-                    <br />
-                    <span className='font-serif italic font-normal text-brand'>
-                        application framework
-                    </span>
-                    <br />
-                    for Rust
-                </h1>
-            </FadeUp>
-
-            <FadeUp delay='200ms' className='max-w-xl mx-auto'>
-                <p className='text-base md:text-lg text-fd-muted-foreground font-medium leading-relaxed mb-10'>
-                    Modules, DI, controllers, pipelines, lifecycle hooks, WebSocket
-                    gateways, and an Axum adapter — zero runtime reflection, no global
-                    mutable state.
-                </p>
-            </FadeUp>
-
-            <FadeUp delay='300ms' className='flex flex-col sm:flex-row gap-4 justify-center items-center w-full mb-8'>
-                <Button
-                    asChild
-                    size='lg'
-                    className='h-12 px-8 rounded-full bg-brand hover:bg-brand/90 text-white font-semibold text-sm shadow-lg shadow-brand/20 transition-all hover:shadow-brand/30 hover:scale-[1.02]'>
-                    <Link to='/docs/getting-started'>
-                        Get started
-                        <ArrowRight className='ml-2 w-4 h-4' />
-                    </Link>
-                </Button>
-                <Button
-                    asChild
-                    variant='outline'
-                    size='lg'
-                    className='h-12 px-8 rounded-full border-fd-border hover:bg-fd-accent hover:text-fd-accent-foreground font-semibold text-sm transition-all'>
-                    <a href='https://github.com/ironic-org/ironic' target='_blank' rel='noopener noreferrer' className='inline-flex items-center'>
-                        <Github className='mr-2 w-4 h-4' />
-                        View on GitHub
-                        <GitHubStarButton />
-                    </a>
-                </Button>
-            </FadeUp>
-
-            <FadeUp delay='350ms' className='mb-6'>
-                <button
-                    onClick={handleCopy}
-                    className='inline-flex items-center gap-2 rounded-full border border-fd-border bg-fd-card/30 px-5 py-2.5 text-xs font-mono text-fd-muted-foreground hover:border-brand/40 hover:text-fd-foreground hover:bg-brand/5 transition-all'>
-                    <Terminal className='w-3.5 h-3.5 text-brand' />
-                    <span>{installCmd}</span>
-                    <span className='text-[10px] text-fd-muted-foreground/60 ml-1 hidden sm:inline'>
-                        -- one command
-                    </span>
-                    <Copy className='w-3 h-3 ml-1 opacity-50' />
-                    {copied && (
-                        <span className='text-[10px] text-emerald-500 font-medium animate-in'>
-                            Copied!
-                        </span>
-                    )}
-                </button>
-            </FadeUp>
-
-            <FadeUp delay='400ms' className='w-full max-w-2xl relative'>
-                <div className='absolute inset-0 bg-brand/5 rounded-xl blur-xl' />
-                <div className='relative rounded-xl border border-fd-border bg-fd-card/90 p-4 text-left shadow-lg'>
-                    <div className='flex items-center gap-1.5 mb-3 border-b border-fd-border pb-3'>
-                        <span className='w-2.5 h-2.5 rounded-full bg-red-400' />
-                        <span className='w-2.5 h-2.5 rounded-full bg-amber-400' />
-                        <span className='w-2.5 h-2.5 rounded-full bg-emerald-400' />
-                        <span className='ml-3 text-[11px] font-medium text-fd-muted-foreground font-mono'>
-                            src/controller.rs
-                        </span>
+            <div className='relative z-10 mx-auto flex min-h-[100svh] max-w-7xl flex-col justify-center px-6 pb-28 pt-28'>
+                <FadeUp className='mb-8 flex items-center gap-4'>
+                    <img
+                        src='/logo.svg'
+                        alt=''
+                        width={72}
+                        height={72}
+                        className='size-16 rounded-[1.15rem] shadow-[0_20px_50px_-24px_rgba(224,120,64,0.55)] sm:size-[4.5rem]'
+                    />
+                    <div className='text-left'>
+                        <p className='font-display text-5xl font-extrabold tracking-tight text-fd-foreground sm:text-6xl md:text-7xl'>
+                            Ironic
+                        </p>
+                        <p className='mt-1 text-sm font-medium tracking-[0.18em] text-brand uppercase'>
+                            Rust application framework
+                        </p>
                     </div>
-                    <pre className='text-sm leading-relaxed overflow-x-auto font-mono'>
-                        <code className='text-fd-foreground'>
-                            {`#[controller("/users")]
-struct UsersController;
+                </FadeUp>
 
-#[routes]
-impl UsersController {
-    #[get("/:id")]
-    async fn get(
-        &self,
-        #[param] id: u64,
-    ) -> Result<Json<UserView>, HttpError> {
-        Ok(Json(self.service.find(id).await?))
-    }
-}`}</code>
-                    </pre>
-                </div>
-            </FadeUp>
+                <FadeUp delay='100ms'>
+                    <h1 className='max-w-3xl text-left font-display text-3xl font-bold tracking-tight text-fd-foreground sm:text-4xl md:text-5xl'>
+                        Ship structured APIs without fighting the framework.
+                    </h1>
+                </FadeUp>
+
+                <FadeUp delay='200ms' className='mt-5 max-w-xl'>
+                    <p className='text-left text-base font-medium leading-relaxed text-fd-muted-foreground md:text-lg'>
+                        Nest-style modules and DI on Axum — typed controllers, pipelines, and
+                        production tooling with zero runtime reflection.
+                    </p>
+                </FadeUp>
+
+                <FadeUp delay='300ms' className='mt-10 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center'>
+                    <Button
+                        asChild
+                        size='lg'
+                        className='h-12 rounded-xl bg-brand px-8 text-sm font-semibold text-white shadow-[0_16px_40px_-18px_rgba(224,120,64,0.75)] transition-all hover:bg-brand/90 hover:scale-[1.02]'>
+                        <Link to='/docs/getting-started'>
+                            Get started
+                            <ArrowRight className='ml-2 h-4 w-4' />
+                        </Link>
+                    </Button>
+                    <Button
+                        asChild
+                        variant='outline'
+                        size='lg'
+                        className='h-12 rounded-xl border-fd-border px-8 text-sm font-semibold transition-all hover:bg-fd-accent hover:text-fd-accent-foreground'>
+                        <a
+                            href='https://github.com/ironic-org/ironic'
+                            target='_blank'
+                            rel='noopener noreferrer'
+                            className='inline-flex items-center'>
+                            <Github className='mr-2 h-4 w-4' />
+                            View on GitHub
+                            <GitHubStarButton />
+                        </a>
+                    </Button>
+                </FadeUp>
+            </div>
         </section>
     );
 };

--- a/docs/src/pages/home/components/navigation.tsx
+++ b/docs/src/pages/home/components/navigation.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Github, Menu, X, GitBranch } from 'lucide-react';
+import { Github, Menu, X } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { GitHubStatsBadge } from './github-stars';
 import { GIT_BRANCH } from '@/lib/constants';
@@ -31,11 +31,15 @@ const Navigation = () => {
     return (
         <nav className='sticky top-0 z-50 w-full border-b border-fd-border bg-fd-background/80 backdrop-blur-md'>
             <div className='mx-auto flex h-16 max-w-7xl items-center justify-between px-6'>
-                <Link to='/' className='flex items-center gap-2'>
-                    <span className='flex items-center justify-center rounded-lg border border-brand/20 bg-brand/10 p-1.5'>
-                        <img src='/logo.svg' alt='Ironic' width='20' height='20' className='size-5' />
-                    </span>
-                    <span className='text-lg font-bold tracking-tight text-fd-foreground'>
+                <Link to='/' className='flex items-center gap-2.5'>
+                    <img
+                        src='/logo.svg'
+                        alt='Ironic'
+                        width={28}
+                        height={28}
+                        className='size-7 rounded-lg shadow-sm'
+                    />
+                    <span className='font-display text-lg font-bold tracking-tight text-fd-foreground'>
                         Ironic
                     </span>
                     <span className='inline-flex items-center gap-1 rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/50 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-300 max-md:hidden'>

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -53,6 +53,9 @@
     --animate-spin-slow: spin 8s linear infinite;
     --animate-float: float 6s ease-in-out infinite;
     --animate-glow: glow 4s ease-in-out infinite;
+    --animate-drift: drift 18s ease-in-out infinite;
+    --animate-node-pulse: node-pulse 3.5s ease-in-out infinite;
+    --font-display: var(--theme-font-display);
 
     @keyframes beam {
         0% { top: -200px; opacity: 0; }
@@ -75,6 +78,16 @@
     @keyframes glow {
         0%, 100% { opacity: 0.3; }
         50% { opacity: 0.7; }
+    }
+
+    @keyframes drift {
+        0%, 100% { transform: translate3d(0, 0, 0) scale(1); }
+        50% { transform: translate3d(2%, -3%, 0) scale(1.04); }
+    }
+
+    @keyframes node-pulse {
+        0%, 100% { opacity: 0.35; transform: scale(1); }
+        50% { opacity: 0.9; transform: scale(1.15); }
     }
 }
 
@@ -131,6 +144,11 @@
 
     body {
         @apply bg-fd-background text-foreground;
+        font-family: var(--font-sans);
+    }
+
+    .font-display {
+        font-family: var(--font-display), var(--font-sans);
     }
 
     #nd-sidebar .nd-sidebar-item[data-active='true'] {


### PR DESCRIPTION
## Summary
- Replace the purple I-mark with a copper modular logo and matching favicon/manifest assets
- Put the Ironic brand first in the hero and reduce first-viewport clutter
- Update typography and accent defaults across nav, footer, CTA, features, and related landing sections

## Test plan
1. From the repo root, start the docs site:
   ```bash
   cd docs
   npm install
   npm run dev
   ```
2. Vite will print a local URL (usually `http://localhost:3002/`). Open that URL in your browser.
3. Confirm the logo + **Ironic** brand dominate the first viewport (not buried in nav only).
4. Toggle light/dark theme — accent and logo should stay coherent.
5. Check the browser tab favicon and that `docs/public/site.webmanifest` icons look correct.
6. Spot-check nav, footer, CTA, features, comparison table, and code showcase for accent consistency.
7. Run:
   ```bash
   cd docs && npm run check-types
   ```